### PR TITLE
Simplify Ansible setup

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,8 +1,3 @@
 [defaults]
 remote_user = ec2-user
 force_color=True
-
-[ssh_connection]
-# This is required for Spacelift public workers because gvisor does not allow
-# for creating control sockets in mounted directory.
-control_path_dir=/tmp/.ansible/cp

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,6 +1,6 @@
 - name: will wait till reachable
   hosts: all
-  gather_facts: false # important
+  gather_facts: false # we just created the EC2 machine, so we want for the machine to become accessible before gathering facts
   ignore_unreachable: true
   vars_files:
         - vars/default.yml

--- a/management/stacks.tf
+++ b/management/stacks.tf
@@ -5,10 +5,10 @@ resource "random_string" "stack_name_suffix" {
 
 # Terraform stack
 resource "spacelift_stack" "terraform-ansible-workflow-terraform" {
-  branch         = "main"
+  branch         = data.spacelift_stack.current_stack.branch
   name           = "Terraform Ansible Workflow - Terraform - ${random_string.stack_name_suffix.result}"
   project_root   = "terraform"
-  repository     = var.github_repository_name
+  repository     = data.spacelift_stack.current_stack.repository
   labels         = toset(var.spacelift_labels)
   administrative = true
   autodeploy     = true
@@ -72,10 +72,10 @@ resource "spacelift_stack" "terraform-ansible-workflow-ansible" {
     playbook = "playbook.yml"
   }
 
-  branch       = "main"
+  branch       = data.spacelift_stack.current_stack.branch
   name         = "Terraform Ansible Workflow - Ansible - ${random_string.stack_name_suffix.result}"
   project_root = "ansible"
-  repository   = var.github_repository_name
+  repository   = data.spacelift_stack.current_stack.repository
   labels       = toset(concat(var.spacelift_labels, ["depends-on:${spacelift_stack.terraform-ansible-workflow-terraform.id}"]))
   autodeploy   = true
 
@@ -114,6 +114,10 @@ resource "spacelift_policy_attachment" "warn-on-unreachable-hosts-ansible" {
 
 # Ignore outside of project root for current stack
 data "spacelift_current_stack" "this" {}
+
+data "spacelift_stack" "current_stack" {
+  stack_id = data.spacelift_current_stack.this.id
+}
 
 resource "spacelift_policy_attachment" "ignore-outside-project-root-this" {
   policy_id = spacelift_policy.ignore-outside-project-root.id

--- a/management/stacks.tf
+++ b/management/stacks.tf
@@ -86,19 +86,14 @@ resource "spacelift_stack" "terraform-ansible-workflow-ansible" {
     }
   }
 
-  runner_image = "public.ecr.aws/spacelift/runner-ansible:latest"
+  runner_image = "public.ecr.aws/spacelift/runner-ansible-aws:latest"
+}
 
-  after_init = [
-    "pip3 install --target=/mnt/workspace/pip boto3 botocore",
-    "export PYTHONPATH=/mnt/workspace/pip",
-    "chmod 600 /mnt/workspace/tf-ansible-key.pem",
-    "mv /mnt/workspace/source/ansible/ansible.cfg /mnt/workspace/ansible.cfg",
-    "export ANSIBLE_CONFIG=/mnt/workspace/ansible.cfg",
-  ]
-
-  before_apply = [
-    "chmod 600 /mnt/workspace/tf-ansible-key.pem",
-  ]
+resource "spacelift_environment_variable" "ansible_config_env_var" {
+  stack_id   = spacelift_stack.terraform-ansible-workflow-ansible.id
+  name       = "ANSIBLE_CONFIG"
+  value      = "/mnt/workspace/source/ansible/ansible.cfg"
+  write_only = false
 }
 
 # Ansible stack attachments

--- a/management/variables.tf
+++ b/management/variables.tf
@@ -16,8 +16,3 @@ variable "github_org_name" {
   type    = string
   default = ""
 }
-
-variable "github_repository_name" {
-  type    = string
-  default = "terraform-ansible-workflow-demo"
-}

--- a/terraform/keys.tf
+++ b/terraform/keys.tf
@@ -20,6 +20,7 @@ resource "spacelift_mounted_file" "ansible-key" {
   relative_path = "tf-ansible-key.pem"
   content       = base64encode(nonsensitive(tls_private_key.rsa-ansible.private_key_pem))
   write_only    = true
+  file_mode     = "600"
 }
 
 resource "spacelift_environment_variable" "ansible_private_key_file" {


### PR DESCRIPTION
A number of simplifications:
- we do not need SSH configuration anymore
- we are using mounted files file_mode attribute from the latest spacelift terraform provider
- using AWS specific runner image: `public.ecr.aws/spacelift/runner-ansible-aws:latest`